### PR TITLE
X11 support experimental

### DIFF
--- a/egmde.cpp
+++ b/egmde.cpp
@@ -26,6 +26,11 @@
 #include <miral/keymap.h>
 #include <miral/runner.h>
 #include <miral/set_window_management_policy.h>
+#include <miral/version.h>
+
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(2, 4, 0)
+#include <miral/x11_support.h>
+#endif
 
 #include <linux/input.h>
 
@@ -77,6 +82,9 @@ int main(int argc, char const* argv[])
 
     return runner.run_with(
         {
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(2, 4, 0)
+            X11Support{},
+#endif
             CommandLineOption{[&](auto& option) { wallpaper.top(option);},
                               "wallpaper-top",    "Colour of wallpaper RGB", "0x000000"},
             CommandLineOption{[&](auto& option) { wallpaper.bottom(option);},


### PR DESCRIPTION
Enable experimental X11 support (when built with libmiral-dev from ppa:mir-team/dev)

Also needs:
```
$ cat ~/.config/egmde.config 
env-hacks=MIR_X11_LAZY=on
x11-display-experimental=3
``` 
