### PR TITLE
Use $EGMDE_SHM_DIR or $XDG_RUNTIME_DIR for shm files in preference to /dev/shm

### DIFF
--- a/egfullscreenclient.cpp
+++ b/egfullscreenclient.cpp
@@ -232,7 +232,17 @@ void egmde::FullscreenClient::on_new_output(Output const* output)
 auto egmde::FullscreenClient::make_shm_pool(int size, void **data) const
 -> std::unique_ptr<wl_shm_pool, void(*)(wl_shm_pool*)>
 {
-    mir::Fd fd{open("/dev/shm", O_TMPFILE | O_RDWR | O_EXCL, S_IRWXU)};
+    static char const* const shm_dir = []()
+        {
+            if (char const* result = getenv("EGMDE_SHM_DIR"))
+                return result;
+            if (char const* result = getenv("XDG_RUNTIME_DIR"))
+                return result;
+
+            return "/dev/shm";
+        }();
+
+    mir::Fd fd{open(shm_dir, O_TMPFILE | O_RDWR | O_EXCL, S_IRWXU)};
     if (fd < 0) {
         BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to open shm buffer"}));
     }


### PR DESCRIPTION
The egmde based snaps currently need the `mir` interface to create unlinked shm files in "/dev/shm". We would like to deprecate the `mir` interface, so this is a problem.

Wayland based toolkits typically use $XDG_RUNTIME_DIR instead, so we try that before "/dev/shm".

The Mir server snaps based on egmde need to change $XDG_RUNTIME_DIR so that `wayland-0` is usable by client snaps, so we also introduce $EGMDE_SHM_DIR so that we don't try to create shm files in the changed directory.

(It's all weird anyway as the files don't ever appear in the directory anyway, just in the tempfs filesystem.)