### PR TITLE
Use /tmp for unlinked shm files

### DIFF
--- a/egfullscreenclient.cpp
+++ b/egfullscreenclient.cpp
@@ -232,7 +232,7 @@ void egmde::FullscreenClient::on_new_output(Output const* output)
 auto egmde::FullscreenClient::make_shm_pool(int size, void **data) const
 -> std::unique_ptr<wl_shm_pool, void(*)(wl_shm_pool*)>
 {
-    mir::Fd fd{open("/dev/shm", O_TMPFILE | O_RDWR | O_EXCL, S_IRWXU)};
+    mir::Fd fd{open("/tmp", O_TMPFILE | O_RDWR | O_EXCL, S_IRWXU)};
     if (fd < 0) {
         BOOST_THROW_EXCEPTION((std::system_error{errno, std::system_category(), "Failed to open shm buffer"}));
     }


### PR DESCRIPTION
The egmde based snaps currently need the `mir` interface to create unlinked shm files in "/dev/shm". We would like to deprecate the mir interface, so this is a problem.

As each snap gets its own "/tmp", and we're not linking the files anyway, that seems a better location to use.