### PR TITLE
Add and use a terminal launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,11 @@ add_custom_target(egmde-launch ALL
     cp ${CMAKE_CURRENT_SOURCE_DIR}/egmde-launch.sh ${CMAKE_BINARY_DIR}/egmde-launch
 )
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/egmde-launch ${CMAKE_BINARY_DIR}/egmde
+add_custom_target(egmde-terminal ALL
+    cp ${CMAKE_CURRENT_SOURCE_DIR}/egmde-terminal ${CMAKE_BINARY_DIR}
+)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/egmde-launch ${CMAKE_BINARY_DIR}/egmde-terminal ${CMAKE_BINARY_DIR}/egmde
     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 )
 

--- a/egmde-terminal
+++ b/egmde-terminal
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+for terminal in gnome-terminal.real gnome-terminal weston-terminal qterminal lxterminal x-terminal-emulator xdg-terminal
+do
+  if which $terminal > /dev/null 2>&1
+  then break;
+  fi
+done
+
+# When testing, we often want to launch a terminal within the Mir session
+# while there's an existing desktop: either as a nested window, or after
+# VT switching.
+#
+# This doesn't fit with gnome-terminal's default behaviour: it tries to run as
+# a single process and any attempt to launch a second instance:
+#
+#   1. appears on the desktop that owns the first terminal; and,
+#   2. the process exits immediately so we can't wait for the exit
+#      (e.g. in miral-app).
+if [ "$terminal" != "gnome-terminal.real" ] && [ "$terminal" != "gnome-terminal" ]
+then
+  # Other terminals default to running as a separate process, which suits us.
+  $terminal "$@"&
+else
+  # What we do is launch the gnome-terminal-server with a distinct --app-id and,
+  # in the next few seconds, launch gnome-terminal with the same --app-id.
+  #
+  # On Ubuntu 16.04 and 18.04 gnome-terminal-server is in /usr/lib/gnome-terminal
+  # On Fedora and Ubuntu 20.04 gnome-terminal-server is in /usr/libexec/
+  # On Arch gnome-terminal-server is in /usr/lib/
+  for terminal_server in /usr/libexec/gnome-terminal-server /usr/lib/gnome-terminal/gnome-terminal-server /usr/lib/gnome-terminal-server
+  do
+    if [ -x "$terminal_server" ];  then break; fi
+  done
+  $terminal_server --app-id io.mirserver.egmdeTerminal&
+  sleep 0.1
+  $terminal --app-id io.mirserver.egmdeTerminal
+fi

--- a/egmde.cpp
+++ b/egmde.cpp
@@ -35,25 +35,6 @@
 
 using namespace miral;
 
-namespace
-{
-// Neither xdg-terminal nor x-terminal-emulator is guaranteed to exist,
-// and neither is a good way to identify user preference...
-std::string const terminal_cmd = []() -> std::string
-    {
-        auto const user_bin = "/usr/bin/";
-
-        for (std::string name : { "weston-terminal", "gnome-terminal", "konsole",
-                                  "qterminal", "lxterminal", "xdg-terminal"})
-        {
-            if (boost::filesystem::exists(user_bin + name))
-                return name;
-        }
-
-        return "x-terminal-emulator";
-    }();
-}
-
 int main(int argc, char const* argv[])
 {
     MirRunner runner{argc, argv};
@@ -62,6 +43,8 @@ int main(int argc, char const* argv[])
 
     ExternalClientLauncher external_client_launcher;
     egmde::Launcher launcher{external_client_launcher};
+
+    auto const terminal_cmd = std::string{argv[0]} + "-terminal";
 
     auto const keyboard_shortcuts = [&](MirEvent const* event)
         {


### PR DESCRIPTION
Steal & adapt the terminal launch script from miral-shell.

This fixes terminal launching on non-Ubuntu distros (e.g. Fedora).