### PR TITLE
Usibility tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ add_executable(egmde
     egwindowmanager.cpp egwindowmanager.h
     egworker.cpp egworker.h
     printer.cpp printer.h
-        egfullscreenclient.cpp egfullscreenclient.h)
+    egfullscreenclient.cpp egfullscreenclient.h
+    egshellcommands.cpp egshellcommands.h
+)
 
 execute_process(
     COMMAND grep ^NAME= /etc/os-release 

--- a/egmde-launch.sh
+++ b/egmde-launch.sh
@@ -4,18 +4,6 @@ set -e
 bindir=$(dirname $0)
 if [ "${bindir}" != "" ]; then bindir="${bindir}/"; fi
 
-while [ $# -gt 0 ]
-do
-  if [ "$1" == "--help" -o "$1" == "-h" ]
-  then
-    echo "$(basename $0) - Handy launch script for egmde on the desktop"
-    echo "Usage: $(basename $0) [shell options]"
-    exit 0
-  else break
-  fi
-  shift
-done
-
 if [ ! -d "${XDG_RUNTIME_DIR}" ]
 then
   echo "Error: XDG_RUNTIME_DIR '${XDG_RUNTIME_DIR}' does not exists"

--- a/egmde-launch.sh
+++ b/egmde-launch.sh
@@ -22,10 +22,11 @@ then
   exit 1
 fi
 
-if [ ! -z "${WAYLAND_DISPLAY}" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]
+if [ ! -z "${WAYLAND_DISPLAY}" ] && [ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]
 then
-  echo "Error: wayland endpoint '${WAYLAND_DISPLAY}' already exists"
-  exit 1
+  echo "Info: wayland endpoint '${WAYLAND_DISPLAY}' already exists, using it as host"
+  export MIR_SERVER_WAYLAND_HOST=${WAYLAND_DISPLAY}
+  unset WAYLAND_DISPLAY
 fi
 
 keymap_index=$(gsettings get org.gnome.desktop.input-sources current | cut -d\  -f 2)

--- a/egmde.desktop
+++ b/egmde.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=egmde
-Comment=The example Mir server
-Exec=egmde-launch
+Comment=The example Mir desktop environment
+Exec=sh -l -c egmde-launch
 Type=Application

--- a/egshellcommands.cpp
+++ b/egshellcommands.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2020 Octopull Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#include "egshellcommands.h"
+#include "eglauncher.h"
+#include <miral/runner.h>
+
+#include <linux/input.h>
+
+egmde::ShellCommands::ShellCommands(MirRunner& runner, Launcher& launcher, std::string const& terminal_cmd) :
+    runner{runner}, launcher{launcher}, terminal_cmd{terminal_cmd}
+{
+}
+
+void egmde::ShellCommands::advise_new_window_for(miral::Application const& app)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+
+    if (shell_apps.find(app) == shell_apps.end())
+    {
+        ++app_windows;
+    }
+}
+
+void egmde::ShellCommands::advise_delete_window_for(miral::Application const& app)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+
+    if (shell_apps.find(app) == shell_apps.end())
+    {
+        --app_windows;
+    }
+}
+
+void egmde::ShellCommands::add_shell_app(miral::Application const& app)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+
+    shell_apps.insert(app);
+}
+
+void egmde::ShellCommands::del_shell_app(miral::Application const& app)
+{
+    std::lock_guard<decltype(mutex)> lock{mutex};
+
+    shell_apps.erase(app);
+}
+
+auto egmde::ShellCommands::keyboard_shortcuts(MirKeyboardEvent const* kev) -> bool
+{
+    if (mir_keyboard_event_action(kev) == mir_keyboard_action_up)
+        return false;
+
+    MirInputEventModifiers mods = mir_keyboard_event_modifiers(kev);
+    if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
+        return false;
+
+    switch (mir_keyboard_event_scan_code(kev))
+    {
+        case KEY_A:launcher.show();
+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+                return false;
+            return true;
+
+        case KEY_BACKSPACE:
+            if (mir_keyboard_event_action(kev) == mir_keyboard_action_down)
+            {
+                std::lock_guard<decltype(mutex)> lock{mutex};
+                if (app_windows > 0)
+                {
+                    return false;
+                }
+            }
+            runner.stop();
+            return true;
+
+        case KEY_T:
+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+                return false;
+            launcher.run_app(terminal_cmd, egmde::Launcher::Mode::wayland);
+            return true;
+
+        case KEY_X:
+            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+                return false;
+            launcher.run_app(terminal_cmd, egmde::Launcher::Mode::x11);
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+auto egmde::ShellCommands::touch_shortcuts(MirTouchEvent const* tev) -> bool
+{
+    if (in_touch_gesture)
+    {
+        if (mir_touch_event_action(tev, 0) == mir_touch_action_up)
+            in_touch_gesture = false;
+        return true;
+    }
+
+    if (mir_touch_event_point_count(tev) != 1)
+        return false;
+
+    if (mir_touch_event_action(tev, 0) != mir_touch_action_down)
+        return false;
+
+    if (mir_touch_event_axis_value(tev, 0, mir_touch_axis_x) >= 5)
+        return false;
+
+    launcher.show();
+    in_touch_gesture = true;
+    return true;
+}
+
+auto egmde::ShellCommands::input_event(MirEvent const* event) -> bool
+{
+    if (mir_event_get_type(event) != mir_event_type_input)
+        return false;
+
+    auto const* input_event = mir_event_get_input_event(event);
+
+    switch (mir_input_event_get_type(input_event))
+    {
+    case mir_input_event_type_touch:
+        return touch_shortcuts(mir_input_event_get_touch_event(input_event));
+
+    case mir_input_event_type_key:
+        return keyboard_shortcuts(mir_input_event_get_keyboard_event(input_event));
+
+    default:
+        return false;
+    }
+}

--- a/egshellcommands.cpp
+++ b/egshellcommands.cpp
@@ -18,6 +18,8 @@
 
 #include "egshellcommands.h"
 #include "eglauncher.h"
+#include "egwindowmanager.h"
+
 #include <miral/runner.h>
 
 #include <linux/input.h>
@@ -104,6 +106,22 @@ auto egmde::ShellCommands::keyboard_shortcuts(MirKeyboardEvent const* kev) -> bo
         launcher.run_app(terminal_cmd, egmde::Launcher::Mode::x11);
         return true;
 
+    case KEY_LEFT:
+        wm->dock_active_window_left();
+        return true;
+
+    case KEY_RIGHT:
+        wm->dock_active_window_right();
+        return true;
+
+    case KEY_UP:
+        wm->workspace_up(mods & mir_input_event_modifier_shift);
+        return true;
+
+    case KEY_DOWN:
+        wm->workspace_down(mods & mir_input_event_modifier_shift);
+        return true;
+
     default:
         return false;
     }
@@ -150,4 +168,9 @@ auto egmde::ShellCommands::input_event(MirEvent const* event) -> bool
     default:
         return false;
     }
+}
+
+void egmde::ShellCommands::init_window_manager(WindowManagerPolicy* wm)
+{
+    this->wm = wm;
 }

--- a/egshellcommands.cpp
+++ b/egshellcommands.cpp
@@ -72,37 +72,40 @@ auto egmde::ShellCommands::keyboard_shortcuts(MirKeyboardEvent const* kev) -> bo
 
     switch (mir_keyboard_event_scan_code(kev))
     {
-        case KEY_A:launcher.show();
-            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
-                return false;
-            return true;
-
-        case KEY_BACKSPACE:
-            if (mir_keyboard_event_action(kev) == mir_keyboard_action_down)
-            {
-                std::lock_guard<decltype(mutex)> lock{mutex};
-                if (app_windows > 0)
-                {
-                    return false;
-                }
-            }
-            runner.stop();
-            return true;
-
-        case KEY_T:
-            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
-                return false;
-            launcher.run_app(terminal_cmd, egmde::Launcher::Mode::wayland);
-            return true;
-
-        case KEY_X:
-            if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
-                return false;
-            launcher.run_app(terminal_cmd, egmde::Launcher::Mode::x11);
-            return true;
-
-        default:
+    case KEY_A:
+        if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
             return false;
+
+        add_shell_app(launcher.session());
+        launcher.show();
+        return true;
+
+    case KEY_BACKSPACE:
+        if (mir_keyboard_event_action(kev) == mir_keyboard_action_down)
+        {
+            std::lock_guard<decltype(mutex)> lock{mutex};
+            if (app_windows > 0)
+            {
+                return false;
+            }
+        }
+        runner.stop();
+        return true;
+
+    case KEY_T:
+        if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+            return false;
+        launcher.run_app(terminal_cmd, egmde::Launcher::Mode::wayland);
+        return true;
+
+    case KEY_X:
+        if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)
+            return false;
+        launcher.run_app(terminal_cmd, egmde::Launcher::Mode::x11);
+        return true;
+
+    default:
+        return false;
     }
 }
 

--- a/egshellcommands.cpp
+++ b/egshellcommands.cpp
@@ -72,7 +72,18 @@ auto egmde::ShellCommands::keyboard_shortcuts(MirKeyboardEvent const* kev) -> bo
     if (!(mods & mir_input_event_modifier_alt) || !(mods & mir_input_event_modifier_ctrl))
         return false;
 
-    switch (mir_keyboard_event_scan_code(kev))
+    auto const scan_code = mir_keyboard_event_scan_code(kev);
+
+    if (scan_code == KEY_DELETE && mir_keyboard_event_action(kev) == mir_keyboard_action_down)
+    {
+        shell_commands_active = !shell_commands_active;
+        return true;
+    }
+
+    if (!shell_commands_active)
+        return false;
+
+    switch (scan_code)
     {
     case KEY_A:
         if (mir_keyboard_event_action(kev) != mir_keyboard_action_down)

--- a/egshellcommands.h
+++ b/egshellcommands.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Octopull Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alan Griffiths <alan@octopull.co.uk>
+ */
+
+#ifndef EGMDE_EGSHELLCOMMANDS_H
+#define EGMDE_EGSHELLCOMMANDS_H
+
+#include <miral/application.h>
+#include <miral/version.h>
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(3, 0, 0)
+#include <miral/toolkit_event.h>
+
+using namespace miral::toolkit;
+#endif
+
+#include <set>
+#include <string>
+#include <mutex>
+
+namespace miral { class MirRunner; }
+namespace egmde
+{
+using namespace miral;
+class Wallpaper;
+class Launcher;
+
+class ShellCommands
+{
+public:
+    ShellCommands(MirRunner& runner, Launcher& launcher, std::string const& terminal_cmd);
+
+    void advise_new_window_for(Application const& app);
+    void advise_delete_window_for(Application const& app);
+
+    void add_shell_app(Application const& app);
+    void del_shell_app(Application const& app);
+
+    auto input_event(MirEvent const* event) -> bool;
+
+private:
+    auto keyboard_shortcuts(MirKeyboardEvent const* kev) -> bool;
+    auto touch_shortcuts(MirTouchEvent const* tev) -> bool;
+
+    MirRunner& runner;
+    Launcher& launcher;
+    std::string const terminal_cmd;
+
+    std::mutex mutex;
+    std::set<Application> shell_apps;
+    int app_windows = 0;
+    bool in_touch_gesture = false;
+};
+}
+
+#endif //EGMDE_EGSHELLCOMMANDS_H

--- a/egshellcommands.h
+++ b/egshellcommands.h
@@ -63,6 +63,7 @@ private:
     Launcher& launcher;
     std::string const terminal_cmd;
     WindowManagerPolicy* wm = nullptr;
+    bool shell_commands_active = true;
 
     std::mutex mutex;
     std::set<Application> shell_apps;

--- a/egshellcommands.h
+++ b/egshellcommands.h
@@ -35,13 +35,17 @@ namespace miral { class MirRunner; }
 namespace egmde
 {
 using namespace miral;
-class Wallpaper;
+
 class Launcher;
+class Wallpaper;
+class WindowManagerPolicy;
 
 class ShellCommands
 {
 public:
     ShellCommands(MirRunner& runner, Launcher& launcher, std::string const& terminal_cmd);
+
+    void init_window_manager(WindowManagerPolicy* wm);
 
     void advise_new_window_for(Application const& app);
     void advise_delete_window_for(Application const& app);
@@ -58,6 +62,7 @@ private:
     MirRunner& runner;
     Launcher& launcher;
     std::string const terminal_cmd;
+    WindowManagerPolicy* wm = nullptr;
 
     std::mutex mutex;
     std::set<Application> shell_apps;

--- a/egwindowmanager.cpp
+++ b/egwindowmanager.cpp
@@ -44,12 +44,16 @@ inline WorkspaceInfo& workspace_info_for(WindowInfo const& info)
 }
 }
 
-egmde::WindowManagerPolicy::WindowManagerPolicy(WindowManagerTools const& tools, Wallpaper const& wallpaper, ShellCommands&commands) :
+egmde::WindowManagerPolicy::WindowManagerPolicy(
+    WindowManagerTools const& tools,
+    Wallpaper const& wallpaper,
+    ShellCommands& commands,
+    int const& no_of_workspaces) :
     MinimalWindowManager{tools},
     wallpaper{&wallpaper},
     commands{&commands}
 {
-    for (auto i = 0; i != 4; ++i)
+    for (auto i = 0; i != no_of_workspaces; ++i)
         workspaces.push_back(this->tools.create_workspace());
 
     active_workspace = workspaces.begin();
@@ -237,6 +241,8 @@ void egmde::WindowManagerPolicy::change_active_workspace(
     std::shared_ptr<Workspace> const& old_active,
     Window const& window)
 {
+    if (new_active == old_active) return;
+
     auto const old_active_window = tools.active_window();
 
     if (!old_active_window)

--- a/egwindowmanager.cpp
+++ b/egwindowmanager.cpp
@@ -28,44 +28,6 @@
 using namespace mir::geometry;
 
 
-void egmde::WindowManagerPolicy::keep_size_within_limits(
-    WindowInfo const& window_info, Displacement& delta, Width& new_width, Height& new_height) const
-{
-    auto const min_width  = std::max(window_info.min_width(), Width{5});
-    auto const min_height = std::max(window_info.min_height(), Height{5});
-
-    if (new_width < min_width)
-    {
-        new_width = min_width;
-        if (delta.dx > DeltaX{0})
-            delta.dx = DeltaX{0};
-    }
-
-    if (new_height < min_height)
-    {
-        new_height = min_height;
-        if (delta.dy > DeltaY{0})
-            delta.dy = DeltaY{0};
-    }
-
-    auto const max_width  = window_info.max_width();
-    auto const max_height = window_info.max_height();
-
-    if (new_width > max_width)
-    {
-        new_width = max_width;
-        if (delta.dx < DeltaX{0})
-            delta.dx = DeltaX{0};
-    }
-
-    if (new_height > max_height)
-    {
-        new_height = max_height;
-        if (delta.dy < DeltaY{0})
-            delta.dy = DeltaY{0};
-    }
-}
-
 egmde::WindowManagerPolicy::WindowManagerPolicy(WindowManagerTools const& tools, Wallpaper const& wallpaper) :
     MinimalWindowManager{tools},
     wallpaper{&wallpaper}

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -25,19 +25,26 @@ namespace egmde
 {
 using namespace miral;
 class Wallpaper;
+class ShellCommands;
 
 class WindowManagerPolicy :
     public MinimalWindowManager
 {
 public:
-    WindowManagerPolicy(WindowManagerTools const& tools, Wallpaper const& wallpaper);
+    WindowManagerPolicy(WindowManagerTools const& tools, Wallpaper const& wallpaper, ShellCommands& commands);
 
     auto place_new_window(ApplicationInfo const& app_info, WindowSpecification const& request_parameters)
         -> WindowSpecification override;
 
-private:
-    Wallpaper const* wallpaper;
+    void advise_new_window(const WindowInfo &window_info) override;
 
+    void advise_delete_app(ApplicationInfo const& application) override;
+
+    void advise_delete_window(const WindowInfo &window_info) override;
+
+private:
+    Wallpaper const* const wallpaper;
+    ShellCommands* const commands;
 };
 }
 

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -34,7 +34,11 @@ class WindowManagerPolicy :
     public MinimalWindowManager
 {
 public:
-    WindowManagerPolicy(WindowManagerTools const& tools, Wallpaper const& wallpaper, ShellCommands& commands);
+    WindowManagerPolicy(
+        WindowManagerTools const& tools,
+        Wallpaper const& wallpaper,
+        ShellCommands& commands,
+        int const& no_of_workspaces);
 
     auto place_new_window(ApplicationInfo const& app_info, WindowSpecification const& request_parameters)
         -> WindowSpecification override;

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -21,6 +21,9 @@
 
 #include <miral/minimal_window_manager.h>
 
+#include <map>
+#include <vector>
+
 namespace egmde
 {
 using namespace miral;
@@ -44,9 +47,25 @@ public:
 
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
 
+    void handle_modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
+
+    void advise_adding_to_workspace(std::shared_ptr<Workspace> const& workspace,
+                                    std::vector<Window> const& windows) override;
+
 private:
+    void apply_workspace_hidden_to(Window const& window);
+    void apply_workspace_visible_to(Window const& window);
+    void change_active_workspace(std::shared_ptr<Workspace> const& ww,
+                                 std::shared_ptr<Workspace> const& old_active,
+                                 miral::Window const& window);
+
     Wallpaper const* const wallpaper;
     ShellCommands* const commands;
+
+    using ring_buffer = std::vector<std::shared_ptr<Workspace>>;
+    ring_buffer workspaces;
+    ring_buffer::iterator active_workspace;
+    std::map<std::shared_ptr<miral::Workspace>, miral::Window> workspace_to_active;
 };
 }
 

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -40,8 +40,14 @@ public:
         ShellCommands& commands,
         int const& no_of_workspaces);
 
+    void dock_active_window_left();
+    void dock_active_window_right();
+    void workspace_up(bool take_active);
+    void workspace_down(bool take_active);
+
+private:
     auto place_new_window(ApplicationInfo const& app_info, WindowSpecification const& request_parameters)
-        -> WindowSpecification override;
+    -> WindowSpecification override;
 
     void advise_new_window(const WindowInfo &window_info) override;
 
@@ -49,14 +55,11 @@ public:
 
     void advise_delete_window(const WindowInfo &window_info) override;
 
-    bool handle_keyboard_event(MirKeyboardEvent const* event) override;
-
     void handle_modify_window(WindowInfo& window_info, WindowSpecification const& modifications) override;
 
     void advise_adding_to_workspace(std::shared_ptr<Workspace> const& workspace,
                                     std::vector<Window> const& windows) override;
 
-private:
     void apply_workspace_hidden_to(Window const& window);
     void apply_workspace_visible_to(Window const& window);
     void change_active_workspace(std::shared_ptr<Workspace> const& ww,

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -42,6 +42,8 @@ public:
 
     void advise_delete_window(const WindowInfo &window_info) override;
 
+    bool handle_keyboard_event(MirKeyboardEvent const* event) override;
+
 private:
     Wallpaper const* const wallpaper;
     ShellCommands* const commands;

--- a/egwindowmanager.h
+++ b/egwindowmanager.h
@@ -38,8 +38,6 @@ public:
 private:
     Wallpaper const* wallpaper;
 
-    void keep_size_within_limits(
-        WindowInfo const& window_info, Displacement& delta, Width& new_width, Height& new_height) const;
 };
 }
 


### PR DESCRIPTION
1. You have to hold Ctrl-Alt-BkSp to close if there are apps open
2. Ctrl-Alt-Left/Ctrl-Alt-Right dock active window to left/right
3. Added workspaces
3.1. `--no-of-workspaces 4` to enable 4 workspaces
3.2. Ctrl-Alt-Up/Down to switch workspace
3.3. Ctrl-Alt-Up/Down to switch workspace taking active window
4. Ctrl-Alt-Del to disable/disable window manage commands (the above, Ctrl-Alt-A, Ctrl-Alt-T and Ctrl-Alt-BkSp). (Useful when using egmde as a shell to develop egmde.)