### PR TITLE
Add launch via snapd (behind a feature flag)

### DIFF
--- a/eglauncher.cpp
+++ b/eglauncher.cpp
@@ -725,9 +725,16 @@ void egmde::Launcher::Self::touch_down(
 
 void egmde::Launcher::Self::run_app(Mode mode)
 {
-    auto app = current_app->terminal ? terminal_cmd + " -e " + current_app->exec : current_app->exec;
+    if (getenv("EGMDE_SNAP_LAUNCH"))
+    {
+        external_client_launcher.snapcraft_launch(current_app->desktop_file);
+    }
+    else
+    {
+        auto app = current_app->terminal ? terminal_cmd + " -e " + current_app->exec : current_app->exec;
 
-    ::run_app(external_client_launcher, app, mode);
+        ::run_app(external_client_launcher, app, mode);
+    }
 
     running = false;
     for_each_surface([this](auto& info) { this->draw_screen(info); });

--- a/eglauncher.cpp
+++ b/eglauncher.cpp
@@ -148,6 +148,7 @@ struct app_details
 
         std::string line;
 
+        desktop_dir = desktop_path.parent_path().string();
         desktop_file = desktop_path.filename().string();
 
         auto in_desktop_entry = false;
@@ -186,6 +187,7 @@ struct app_details
         title = name;
     }
 
+    std::string desktop_dir;
     std::string desktop_file;
 
     std::string name;
@@ -725,7 +727,8 @@ void egmde::Launcher::Self::touch_down(
 
 void egmde::Launcher::Self::run_app(Mode mode)
 {
-    if (getenv("EGMDE_SNAP_LAUNCH"))
+    if (getenv("EGMDE_SNAP_LAUNCH") &&
+        current_app->desktop_dir == "/var/lib/snapd/desktop/applications")
     {
         external_client_launcher.snapcraft_launch(current_app->desktop_file);
     }


### PR DESCRIPTION
Allow launching apps via the (in development) `desktop-launch` snap interface when `EGMDE_SNAP_LAUNCH` is set.